### PR TITLE
Add new Segment category "Break Glass" along with "Sync-ZNBreakGlassFiles" package. 

### DIFF
--- a/Segment/Break Glass/Sync-ZNBreakGlassFiles/README.md
+++ b/Segment/Break Glass/Sync-ZNBreakGlassFiles/README.md
@@ -1,0 +1,100 @@
+# Zero Networks Break Glass File Sync
+
+This script is aimed at assisting organizations that wish to have a dedicated server from which to execute a breakglass procedure from. The breakglass procedure requires a certain file (segmentedAssets.json) that is only presented and updated on the segment server(s). So, in order to have a separate break glass server staged and ready to go in the event breakglass is needed, you have to ensure the server has the latest breakglass files from the segment server.
+
+Rather than relying on manually copying these files, this script, when ran, will copy the contents of the BreakGlass directory on the Zero Networks Segment Server (C:\Program Files\Zero Networks\BreakGlass\), to another destination server of your choosing. It does this by connecting to the Segment Server via PSRemoteSession, compressing the directory to an archive, downloading it to the local filedisk (where script is running), and then copying it to the remote servers specified directory (value of the -RemoteDirectory parameter). 
+
+Running this script as a scheduled job will ensure the breakglass server has a (relatively) up to date version of the required files. 
+## Authors
+
+- Thomas Obarowski - [GitHub](https://www.github.com/tjobarow) - [LinkedIn](https://www.linkedin.com/in/tjobarow/)
+
+
+## Usage/Examples
+
+### Dependencies
+In order to run this script successfully, you will need the following:
+- A Windows Server with which you plan to use as a breakglass server
+- A domain account that has local administrator permissions and PSRemoting permission on both the segment and destination breakglass server.
+- PSRemoting must be enabled on both the segment server and destination server
+- **An inbound allow rule that allows the device running the script to WinRM to both the Segment Server and Breakglass Server without MFA** (If applicable)
+
+#### Enabling PSRemoting
+Open an administrator command PowerShell session on the server you want to enable PSRemoting on and run the following:
+```powershell
+Enable-PSRemoting -Force
+```
+
+#### Giving domain account permission for PSRemoting
+On each server the account needs PSRemoting permission on, RDP (or console) into each server (GUI required), and run the following. 
+
+```powershell
+Set-PSSessionConfiguration -Name Microsoft.PowerShell -ShowSecurityDescriptorUI -Force 
+```
+
+This will open up a graphical popup, where you can then add the account and give it "full control" (read/write should work as well, but not tested). There is likely a way to do this without graphical interaction, but I am not sure how (didn't look into it).
+
+### Usage
+
+#### Basic Usage
+Before running the script, will need to import the module:
+```powershell
+cd \path\to\Sync-ZNBreakGlassFiles
+Import-Module .\sync_breakglass_directory.psm1
+```
+After which, you can run the following command within your Powershell session. 
+
+```powershell
+Sync-BreakGlassDirectory -Username $ENV:username -Password $ENV:password -BreakGlassServer $ENV:breakglass_server -SegmentServer $ENV:segment_server -RemoteDirectory $ENV:remote_directory
+```
+
+This is the command will execute the script. You can see there are several parameters that are present:
+- Username - Optionally provide a username for the admin account to use (can use the -Credential parameter (not shown above) to pass the script a PSCredential object instead)
+- Password - Optionally provide the password for the associated admin user (can use the -Credential parameter (not shown above) to pass the script a PSCredential object instead)
+- BreakGlassServer - The destination server to copy the BreakGlass directory to 
+- SegmentServer - The ZN segment server to fetch the BreakGlass directory from
+- RemoteDirectory - The directory you wish to copy the BreakGlass folder to on the BreakGlassServer
+
+#### Providing a PSCredential versus Username/Password
+
+Not shown above is the additional option to provide the script a PSCredential Object instead of a username and password. Doing so would look like:
+
+```powershell
+Sync-BreakGlassDirectory -Credential $Credentials -BreakGlassServer $ENV:breakglass_server -SegmentServer $ENV:segment_server -RemoteDirectory $ENV:remote_directory
+```
+
+or 
+
+```powershell
+Sync-BreakGlassDirectory -Credential (Get-Credential) -BreakGlassServer $ENV:breakglass_server -SegmentServer $ENV:segment_server -RemoteDirectory $ENV:remote_directory
+```
+
+#### Leveraging Environment Variables
+
+As seen above, the basic syntax provided uses PowerShell environment variables in order to avoid hard-coding potentially sensitive data. 
+
+To configure environment variables, simply add them into the **same** PowerShell session you will run the script from by running the following:
+
+```powershell
+$ENV:breakglass_server="myserver1"
+$ENV:segment_server="segserver2"
+$ENV:remote_directory="C:\Users\Public\ZNBreakGlass"
+$ENV:username="myaccount"
+$ENV:password="changethis"
+```
+
+then reference them within the command:
+
+```powershell
+Sync-BreakGlassDirectory -Username $ENV:username -Password $ENV:password -BreakGlassServer $ENV:breakglass_server -SegmentServer $ENV:segment_server -RemoteDirectory $ENV:remote_directory
+```
+
+### Running this script in an automated fashion
+You can easily automate the execution of this script through tools such as Jenkins, or Windows Scheduled Tasks. You just need to make sure you store the parameters securely, as well as pass them to the command securely. This is why I recommend using a full-fledged tool such as Jenkins, in which you can securely store and set environment variables at script execution, instead of saving them into a config file or statically defining them in code. Alternatively, if you have access to a secure devops vault, which you can retrieve secrets from, you could adapt this script to use that. 
+
+## License
+
+[MIT](https://choosealicense.com/licenses/mit/)
+
+
+

--- a/Segment/Break Glass/Sync-ZNBreakGlassFiles/sync_breakglass_directory.psd1
+++ b/Segment/Break Glass/Sync-ZNBreakGlassFiles/sync_breakglass_directory.psd1
@@ -1,7 +1,7 @@
 @{
     ModuleVersion     = '1.0'
     Author            = 'Thomas Obarowski (https://www.linkedin.com/in/tjobarow/)'
-    Description       = 'This module will use a PSSession to connect to the provided Segment Server. It attempts
+    Description       = 'This module will use a PSSession to connect to the provided Segment Server. It then attempts
     to compress C:\Program Files\Zero Networks\BreakGlass\ to BreakGlass.zip, and then copy
     it to the local filesystem (host running module). It then closes the previous pssession
     and enters a new one on the destination server. It copies the breakglass.zip file to 

--- a/Segment/Break Glass/Sync-ZNBreakGlassFiles/sync_breakglass_directory.psd1
+++ b/Segment/Break Glass/Sync-ZNBreakGlassFiles/sync_breakglass_directory.psd1
@@ -1,0 +1,12 @@
+@{
+    ModuleVersion     = '1.0'
+    Author            = 'Thomas Obarowski (https://www.linkedin.com/in/tjobarow/)'
+    Description       = 'This module will use a PSSession to connect to the provided Segment Server. It attempts
+    to compress C:\Program Files\Zero Networks\BreakGlass\ to BreakGlass.zip, and then copy
+    it to the local filesystem (host running module). It then closes the previous pssession
+    and enters a new one on the destination server. It copies the breakglass.zip file to 
+    a remote directory provided at run time. It then closes the pssession and removes the 
+    local copy of BreakGlass.zip'
+    FunctionsToExport = 'Sync-BreakGlassDirectory'
+    RootModule        = '.\sync_breakglass_directory.psm1'
+}

--- a/Segment/Break Glass/Sync-ZNBreakGlassFiles/sync_breakglass_directory.psm1
+++ b/Segment/Break Glass/Sync-ZNBreakGlassFiles/sync_breakglass_directory.psm1
@@ -21,6 +21,19 @@ SEE .EXAMPLES SECTION FOR USAGE
     a remote directory provided at run time. It then closes the pssession and removes the 
     local copy of BreakGlass.zip
 
+.PARAMETER Credential
+    PSCredential object needed to create PSSession to Segment Server
+.PARAMETER Username
+    Account username to use to create PSSession
+.PARAMETER Password
+    Password for the associated username provided
+.PARAMETER SegmentServer
+    SHORT hostname for Segment Server (such as znserver)
+.PARAMETER RemoteDirectory
+    Remote directory to copy the archive into
+.PARAMETER BreakGlassServer
+    SHORT hostname for the BreakGlass (destination) server
+
 .NOTES
     DEPENDENCIES:
     * Inbound allow rule allowing the device running this script to WinRM to both
@@ -52,22 +65,23 @@ SEE .EXAMPLES SECTION FOR USAGE
         Sync-BreakGlassDirectory -Username $ENV:username -Password $ENV:password -BreakGlassServer $ENV:BreakGlassServer -SegmentServer $ENV:SegmentServer -RemoteDirectory $ENV:RemoteDirectory
 #>
 
-<#
-.SYNOPSIS
-    Log-Message function writes a string to stdout and appends to a pre-named log file.
-.DESCRIPTION
-    Accepts a string, adds a timestamp infront of said string, writes to stdout, and then
-    appends to a log file. less verbose than Start-Transcript, but still includes timestamps
-.PARAMETER Message
-    String message to log to stdout and file
-.OUTPUTS
-    None
-.NOTES
-    N/A
-.FUNCTIONALITY
-   Logging Mechanism
-#>
+
 function Log-Message {
+    <#
+    .SYNOPSIS
+        Log-Message function writes a string to stdout and appends to a pre-named log file.
+    .DESCRIPTION
+        Accepts a string, adds a timestamp infront of said string, writes to stdout, and then
+        appends to a log file. less verbose than Start-Transcript, but still includes timestamps
+    .PARAMETER Message
+        String message to log to stdout and file
+    .OUTPUTS
+        None
+    .NOTES
+        N/A
+    .FUNCTIONALITY
+    Logging Mechanism
+    #>
     param(
         [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
         [string]$Message = ""
@@ -76,24 +90,25 @@ function Log-Message {
     "$((Get-Date -Format 'yyyy-MM-dd HH:mm:ss').ToString()) - $Message" | Out-File -FilePath "$((Get-Date -Format 'yyyy-MM-dd').ToString())_sync-BreakGlass-Directory.log" -Append
 }
 
-<#
-.SYNOPSIS
-    Get-Credentials - Creates a PSCredential Object based on provided username/password
-.DESCRIPTION
-    Accepts username and password, converts the password to a securestring, and then
-    creates a PSCredentialObject based on the securestring and username
-.PARAMETER Username
-    Admin account username
-.PARAMETER Password
-    Admin account password
-.OUTPUTS
-    Return PSCredentials object
-.NOTES
-    Information or caveats about the function e.g. 'This function is not supported in Linux'
-.FUNCTIONALITY
-   Create PSCredential object used in other Cmdlets
-#>
+
 function Get-Credentials {
+    <#
+    .SYNOPSIS
+        Get-Credentials - Creates a PSCredential Object based on provided username/password
+    .DESCRIPTION
+        Accepts username and password, converts the password to a securestring, and then
+        creates a PSCredentialObject based on the securestring and username
+    .PARAMETER Username
+        Admin account username
+    .PARAMETER Password
+        Admin account password
+    .OUTPUTS
+        Return PSCredentials object
+    .NOTES
+        Information or caveats about the function e.g. 'This function is not supported in Linux'
+    .FUNCTIONALITY
+    Create PSCredential object used in other Cmdlets
+    #>
     param(
         [Parameter(Mandatory = $true)]
         [string]$Username,
@@ -116,31 +131,32 @@ function Get-Credentials {
     }
 }
 
-<#
-.SYNOPSIS
-    Get-BreakGlassZip - Compresses and copies the contents of 
-    C:\Program Files\Zero Networks\BreakGlass\ on the Segment Server
-    to your local filesystem
-.DESCRIPTION
-    This function requires a valid credential object that has local administrator
-    privileges on the ZN Segment Server, as well as the ComputerName of the Segment
-    Server. It then creates a new PSSession with the Segment Server. It uses
-    Invoke-Command to compress the C:\Program Files\Zero Networks\BreakGlass\ directory
-    to a file named BreakGlass.zip. It then uses Copy-Item -FromSession to copy
-    the BreakGlass.zip from the Segment Server PSSession into the local filesystem
-    where the script is ran from. It then terminates the PSSession to the Segment
-    Server.
-.PARAMETER Credential
-    PSCredential object needed to create PSSession to Segment Server
-.PARAMETER SegmentServer
-    SHORT hostname for Segment Server (such as znserver)
-.OUTPUTS
-    N/A - None
-.NOTES
-    The credentials object used must be enabled for PSRemoting on the segment server
-    and have local admin.
-#>
+
 function Get-BreakGlassZip {
+    <#
+    .SYNOPSIS
+        Get-BreakGlassZip - Compresses and copies the contents of 
+        C:\Program Files\Zero Networks\BreakGlass\ on the Segment Server
+        to your local filesystem
+    .DESCRIPTION
+        This function requires a valid credential object that has local administrator
+        privileges on the ZN Segment Server, as well as the ComputerName of the Segment
+        Server. It then creates a new PSSession with the Segment Server. It uses
+        Invoke-Command to compress the C:\Program Files\Zero Networks\BreakGlass\ directory
+        to a file named BreakGlass.zip. It then uses Copy-Item -FromSession to copy
+        the BreakGlass.zip from the Segment Server PSSession into the local filesystem
+        where the script is ran from. It then terminates the PSSession to the Segment
+        Server.
+    .PARAMETER Credential
+        PSCredential object needed to create PSSession to Segment Server
+    .PARAMETER SegmentServer
+        SHORT hostname for Segment Server (such as znserver)
+    .OUTPUTS
+        N/A - None
+    .NOTES
+        The credentials object used must be enabled for PSRemoting on the segment server
+        and have local admin.
+    #>
     param(
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]$Credential,
@@ -180,36 +196,37 @@ function Get-BreakGlassZip {
     }
 }
 
-<#
-.SYNOPSIS
-    Push-BreakGlassZip - Copies the BreakGlass.zip archive from local folder into the
-    the RemoteDirectory specified on the breakglass (destination) server
-.DESCRIPTION
-    This function requires a valid credential object that has local administrator
-    privileges on the BreakGlass Server, as well as the ComputerName of the Segment
-    Server, ComputerName of the BreakGlass Server, and Remote Directory where the file
-    will be copied to. It then creates a new PSSession with the BreakGlass Server. It uses
-    Invoke-Command to verify the remote directory specified exists, and tries to create
-    it if it does not exist. It then uses Copy-Item -ToSession to copy
-    the BreakGlass.zip from the local filesystem into the BreakGlass server, at the
-    provided remote directory. It renames BreakGlass.zip to include the Segment Server
-    name the archive was retrieved from. It then terminates the PSSession to the Segment
-    Server.
-.PARAMETER Credential
-    PSCredential object needed to create PSSession to Segment Server
-.PARAMETER SegmentServer
-    SHORT hostname for Segment Server (such as znserver)
-.PARAMETER RemoteDirectory
-    Remote directory to copy the archive into
-.PARAMETER BreakGlassServer
-    SHORT hostname for the BreakGlass (destination) server
-.OUTPUTS
-    N/A - None
-.NOTES
-    The credentials object used must be enabled for PSRemoting on the breakglass
-    server and have local admin.
-#>
+
 function Push-BreakGlassZip {
+    <#
+    .SYNOPSIS
+        Push-BreakGlassZip - Copies the BreakGlass.zip archive from local folder into the
+        the RemoteDirectory specified on the breakglass (destination) server
+    .DESCRIPTION
+        This function requires a valid credential object that has local administrator
+        privileges on the BreakGlass Server, as well as the ComputerName of the Segment
+        Server, ComputerName of the BreakGlass Server, and Remote Directory where the file
+        will be copied to. It then creates a new PSSession with the BreakGlass Server. It uses
+        Invoke-Command to verify the remote directory specified exists, and tries to create
+        it if it does not exist. It then uses Copy-Item -ToSession to copy
+        the BreakGlass.zip from the local filesystem into the BreakGlass server, at the
+        provided remote directory. It renames BreakGlass.zip to include the Segment Server
+        name the archive was retrieved from. It then terminates the PSSession to the Segment
+        Server.
+    .PARAMETER Credential
+        PSCredential object needed to create PSSession to Segment Server
+    .PARAMETER SegmentServer
+        SHORT hostname for Segment Server (such as znserver)
+    .PARAMETER RemoteDirectory
+        Remote directory to copy the archive into
+    .PARAMETER BreakGlassServer
+        SHORT hostname for the BreakGlass (destination) server
+    .OUTPUTS
+        N/A - None
+    .NOTES
+        The credentials object used must be enabled for PSRemoting on the breakglass
+        server and have local admin.
+    #>
     param(
         [Parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]$Credential,
@@ -264,38 +281,39 @@ function Push-BreakGlassZip {
     }
 }
 
-<#
-.SYNOPSIS
-    Sync-BreakGlassDirectory - Main function that executes scripts - calls required
-    functions to copy archive from segment server to breakglass server
-.DESCRIPTION
-    This function accepts either a PSCredential object directly, or a username/password,
-    and then determines which was provided. If user/pass, it calls Get-Credential to 
-    convert that to a PSCredential object. It then executes:
-    1. Get-BreakGlassZip
-    2. Push-BreakGlassZip
-    Which copies the BreakGlass directory from the Segement Server to the BreakGlass server
-.PARAMETER Credential
-    PSCredential object needed to create PSSession to Segment Server
-.PARAMETER Username
-    Account username to use to create PSSession
-.PARAMETER Password
-    Password for the associated username provided
-.PARAMETER SegmentServer
-    SHORT hostname for Segment Server (such as znserver)
-.PARAMETER RemoteDirectory
-    Remote directory to copy the archive into
-.PARAMETER BreakGlassServer
-    SHORT hostname for the BreakGlass (destination) server
-.OUTPUTS
-    N/A - None
-.NOTES
-    You can provide either a PSCredential object such as using (Get-Credential)
-    in the function call. OR you can provide it a username/password
-.FUNCTIONALITY
-   Basically the __init__ function of this script
-#>
+
 function Sync-BreakGlassDirectory {
+    <#
+    .SYNOPSIS
+        Sync-BreakGlassDirectory - Main function that executes scripts - calls required
+        functions to copy archive from segment server to breakglass server
+    .DESCRIPTION
+        This function accepts either a PSCredential object directly, or a username/password,
+        and then determines which was provided. If user/pass, it calls Get-Credential to 
+        convert that to a PSCredential object. It then executes:
+        1. Get-BreakGlassZip
+        2. Push-BreakGlassZip
+        Which copies the BreakGlass directory from the Segement Server to the BreakGlass server
+    .PARAMETER Credential
+        PSCredential object needed to create PSSession to Segment Server
+    .PARAMETER Username
+        Account username to use to create PSSession
+    .PARAMETER Password
+        Password for the associated username provided
+    .PARAMETER SegmentServer
+        SHORT hostname for Segment Server (such as znserver)
+    .PARAMETER RemoteDirectory
+        Remote directory to copy the archive into
+    .PARAMETER BreakGlassServer
+        SHORT hostname for the BreakGlass (destination) server
+    .OUTPUTS
+        N/A - None
+    .NOTES
+        You can provide either a PSCredential object such as using (Get-Credential)
+        in the function call. OR you can provide it a username/password
+    .FUNCTIONALITY
+    Basically the __init__ function of this script
+    #>
     param(
         [Parameter(Mandatory = $false)]
         [System.Management.Automation.PSCredential]$Credential = $null,
@@ -334,5 +352,4 @@ function Sync-BreakGlassDirectory {
     Push-BreakGlassZip -Credential $Credential -RemoteDirectory $RemoteDirectory -BreakGlassServer $BreakGlassServer -SegmentServer $SegmentServer
     Log-Message "Completed copying BreakGlass directory from $SegmentServer to $BreakGlassServer at $RemoteDirectory\BreakGlass-From-$($SegmentServer)"
 }
-
 

--- a/Segment/Break Glass/Sync-ZNBreakGlassFiles/sync_breakglass_directory.psm1
+++ b/Segment/Break Glass/Sync-ZNBreakGlassFiles/sync_breakglass_directory.psm1
@@ -1,0 +1,338 @@
+<#PSScriptInfo
+
+SEE .EXAMPLES SECTION FOR USAGE
+
+.VERSION 1.0
+
+.AUTHOR Thomas Obarowski (https://www.linkedin.com/in/tjobarow/)
+
+.COPYRIGHT (c) 2024 Thomas Obarowski
+
+.TAGS Automation Scripts
+
+.SYNOPSIS
+    This module copies the C:\Program Files\Zero Networks\BreakGlass\ directory to a destination server
+
+.DESCRIPTION
+    This module will use a PSSession to connect to the provided Segment Server. It attempts
+    to compress C:\Program Files\Zero Networks\BreakGlass\ to BreakGlass.zip, and then copy
+    it to the local filesystem (host running module). It then closes the previous pssession
+    and enters a new one on the destination server. It copies the breakglass.zip file to 
+    a remote directory provided at run time. It then closes the pssession and removes the 
+    local copy of BreakGlass.zip
+
+.NOTES
+    DEPENDENCIES:
+    * Inbound allow rule allowing the device running this script to WinRM to both
+        the BreakGlass and Segment server without MFA (if applicable)
+    * PSRemoting must be enabled on both servers (Enable-PSRemoting -Force)
+    * Account used must:
+        - Be have PSRemoting permission on the segment and breakglass (destination) server
+            - Run the below command while in a GRAPHICAL session on the server (GUI pop up)
+            - Can set the account to have permissions to PSRemote
+            - Set-PSSessionConfiguration -Name Microsoft.PowerShell -ShowSecurityDescriptorUI -Force 
+        - Be local admin on the segment and breakglass server
+        - Have permission to copy a file to the remote directory you specify
+            - AKA - You should make sure the domain account you are using have permissions
+            to access and write to the remote directory you specify on the destination server
+
+.EXAMPLE
+    To use the script
+        Sync-BreakGlassDirectory -Username "adminUsername" -Password "adminPwd"-BreakGlassServer "destinationServerHostName" -SegmentServer "znSegmentServerHostName" -RemoteDirectory "C:\Users\Public\ZNBreakGlassFiles"
+
+    OR
+        Sync-BreakGlassDirectory -Credential (Get-Credential) -BreakGlassServer "destinationServerHostName" -SegmentServer "znSegmentServerHostName" -RemoteDirectory "C:\Users\Public\ZNBreakGlassFiles"
+
+    OR WITH ENV VARIABLES SET
+        $ENV:segmentServer = "ZnSegmentServer1"
+        $ENV:breakglass_server = "ZnBreakGlassServer1"
+        $ENV:remote_directory = "C:\Users\Public\ZNBreakGlassFiles"
+        $ENV:username = "ad-account-with-admin-username"
+        $ENV:password = "somesecurepassword"
+        Sync-BreakGlassDirectory -Username $ENV:username -Password $ENV:password -BreakGlassServer $ENV:BreakGlassServer -SegmentServer $ENV:SegmentServer -RemoteDirectory $ENV:RemoteDirectory
+#>
+
+<#
+.SYNOPSIS
+    Log-Message function writes a string to stdout and appends to a pre-named log file.
+.DESCRIPTION
+    Accepts a string, adds a timestamp infront of said string, writes to stdout, and then
+    appends to a log file. less verbose than Start-Transcript, but still includes timestamps
+.PARAMETER Message
+    String message to log to stdout and file
+.OUTPUTS
+    None
+.NOTES
+    N/A
+.FUNCTIONALITY
+   Logging Mechanism
+#>
+function Log-Message {
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [string]$Message = ""
+    )
+    Write-Host "$((Get-Date -Format 'yyyy-MM-dd HH:mm:ss').ToString()) - $Message"
+    "$((Get-Date -Format 'yyyy-MM-dd HH:mm:ss').ToString()) - $Message" | Out-File -FilePath "$((Get-Date -Format 'yyyy-MM-dd').ToString())_sync-BreakGlass-Directory.log" -Append
+}
+
+<#
+.SYNOPSIS
+    Get-Credentials - Creates a PSCredential Object based on provided username/password
+.DESCRIPTION
+    Accepts username and password, converts the password to a securestring, and then
+    creates a PSCredentialObject based on the securestring and username
+.PARAMETER Username
+    Admin account username
+.PARAMETER Password
+    Admin account password
+.OUTPUTS
+    Return PSCredentials object
+.NOTES
+    Information or caveats about the function e.g. 'This function is not supported in Linux'
+.FUNCTIONALITY
+   Create PSCredential object used in other Cmdlets
+#>
+function Get-Credentials {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Username,
+        [Parameter(Mandatory = $true)]
+        [string]$Password
+    )
+    try {
+        # Convert password to secure string
+        $svc_pwd = ConvertTo-SecureString "$Password" -AsPlainText -Force
+        # Create new PSCredential based on username and SecureString password
+        $credentials = New-Object System.Management.Automation.PSCredential ($Username, $svc_pwd)
+        Log-Message "Loaded credentials for use with AD. Username: $($credentials.UserName)"
+        #Return credentials object
+        return $credentials
+    }
+    catch {
+        Log-Message "An error occurred when creating the credentials object."
+        Log-Message $Error[0]
+        exit 1
+    }
+}
+
+<#
+.SYNOPSIS
+    Get-BreakGlassZip - Compresses and copies the contents of 
+    C:\Program Files\Zero Networks\BreakGlass\ on the Segment Server
+    to your local filesystem
+.DESCRIPTION
+    This function requires a valid credential object that has local administrator
+    privileges on the ZN Segment Server, as well as the ComputerName of the Segment
+    Server. It then creates a new PSSession with the Segment Server. It uses
+    Invoke-Command to compress the C:\Program Files\Zero Networks\BreakGlass\ directory
+    to a file named BreakGlass.zip. It then uses Copy-Item -FromSession to copy
+    the BreakGlass.zip from the Segment Server PSSession into the local filesystem
+    where the script is ran from. It then terminates the PSSession to the Segment
+    Server.
+.PARAMETER Credential
+    PSCredential object needed to create PSSession to Segment Server
+.PARAMETER SegmentServer
+    SHORT hostname for Segment Server (such as znserver)
+.OUTPUTS
+    N/A - None
+.NOTES
+    The credentials object used must be enabled for PSRemoting on the segment server
+    and have local admin.
+#>
+function Get-BreakGlassZip {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]$Credential,
+        [Parameter(Mandatory = $true)]
+        [string]$SegmentServer
+    )
+    try {
+        # Create new PSSession to Segment Server using the provided credentials
+        Log-Message "Attemping to connect to $SegmentServer via New-PSSession."
+        $RemoteSession = New-PSSession -ComputerName $SegmentServer -Credential $Credential
+        Log-Message "Successfully connected to $SegmentServer via PSSession using $($Credential.UserName)"
+
+        # Define scriptblock that will compress the BreakGlass directory.
+        Log-Message "Attempting to compress the ZN BreakGlass directory to breakGlass.zip file"
+        $CompressScript = {
+            #The args[0] is because we pass the username of the account in use so we can store the zip in it's home folder
+            Compress-Archive -Path "C:\Program Files\Zero Networks\BreakGlass\" -DestinationPath "C:\Users\$($args[0])\BreakGlass.zip" -Update
+        }
+        # Use Invoke-Command to run the Compress-Archive command on the Segment Server
+        Invoke-Command -Session $RemoteSession -ArgumentList $Credential.UserName -ScriptBlock $CompressScript
+        Log-Message "Successfully compressed ZN BreakGlass directory to zip file breakGlass.zip"
+
+        # Copy the BreakGlass.zip archive from the Segment Server (via PSSession) to local directory
+        Log-Message "Attempting to copy BreakGlass.zip file from $SegmentServer to $ENV:COMPUTERNAME"
+        Copy-Item -FromSession $RemoteSession -Path "C:\Users\$($Credential.UserName)\BreakGlass.zip" -Destination .
+        Log-Message "Successfully copied the BreakGlass.zip file from $SegmentServer to $ENV:COMPUTERNAME"
+
+        #Tear down the PSSession
+        Log-Message "Tearing down PSSession to $SegmentServer"
+        Remove-PsSession -Session $RemoteSession
+        Log-Message "Exited PSSession on $SegmentServer"
+    }
+    catch {
+        $Error
+        Log-Message $Error[0]
+        exit 1
+    }
+}
+
+<#
+.SYNOPSIS
+    Push-BreakGlassZip - Copies the BreakGlass.zip archive from local folder into the
+    the RemoteDirectory specified on the breakglass (destination) server
+.DESCRIPTION
+    This function requires a valid credential object that has local administrator
+    privileges on the BreakGlass Server, as well as the ComputerName of the Segment
+    Server, ComputerName of the BreakGlass Server, and Remote Directory where the file
+    will be copied to. It then creates a new PSSession with the BreakGlass Server. It uses
+    Invoke-Command to verify the remote directory specified exists, and tries to create
+    it if it does not exist. It then uses Copy-Item -ToSession to copy
+    the BreakGlass.zip from the local filesystem into the BreakGlass server, at the
+    provided remote directory. It renames BreakGlass.zip to include the Segment Server
+    name the archive was retrieved from. It then terminates the PSSession to the Segment
+    Server.
+.PARAMETER Credential
+    PSCredential object needed to create PSSession to Segment Server
+.PARAMETER SegmentServer
+    SHORT hostname for Segment Server (such as znserver)
+.PARAMETER RemoteDirectory
+    Remote directory to copy the archive into
+.PARAMETER BreakGlassServer
+    SHORT hostname for the BreakGlass (destination) server
+.OUTPUTS
+    N/A - None
+.NOTES
+    The credentials object used must be enabled for PSRemoting on the breakglass
+    server and have local admin.
+#>
+function Push-BreakGlassZip {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]$Credential,
+        [Parameter(Mandatory = $true)]
+        [string]$RemoteDirectory,
+        [Parameter(Mandatory = $true)]
+        [string]$BreakGlassServer,
+        [Parameter(Mandatory = $true)]
+        [string]$SegmentServer
+    )
+    try {
+
+        # Create new PSSession to BreakGlass server using provided credentials
+        Log-Message "Attemping to connect to $BreakGlassServer via New-PSSession."
+        $RemoteSession = New-PSSession -ComputerName $BreakGlassServer -Credential $Credential
+        Log-Message "Successfully connected to $BreakGlassServer via PSSession using $($Credential.UserName)"
+
+        # Create script block that will verify that the remote directory specified exists
+        Log-Message "Verifying directory $RemoteDirectory exists on $BreakGlassServer and creating it if non-existent."
+        $VerifyDirectoryScript = {
+            #args[0] will be the $RemoteDirectory value
+            if (-not (Test-Path -Path $args[0])) {
+                New-Item -Path $args[0] -ItemType Directory
+            }
+            else {
+                Write-Output "$($args[0]) already exists"
+            }
+        }
+        #Use Invoke-Command to run the script block on the breakglass server
+        Invoke-Command -Session $RemoteSession -ArgumentList $RemoteDirectory -ScriptBlock $VerifyDirectoryScript
+        Log-Message "Verfied directory $RemoteDirectory exists on $BreakGlassServer"
+
+        # Copy the BreakGlass.zip archive to the breakglass server, updating the name to include reference to 
+        # the segment server it was fetched from
+        Log-Message "Attempting to copy BreakGlass.zip file from $ENV:COMPUTERNAME to $BreakGlassServer ($RemoteDirectory\BreakGlass-From-$($SegmentServer).zip)"
+        Copy-Item -ToSession $RemoteSession -Path ".\BreakGlass.zip" -Destination "$($RemoteDirectory)\BreakGlass-From-$($SegmentServer).zip"
+        Log-Message "Successfully copied the BreakGlass.zip file from $ENV:COMPUTERNAME to $BreakGlassServer ($RemoteDirectory\BreakGlass-From-$($SegmentServer).zip)"
+
+        # Tear down the PSSession to the BreakGlass server
+        Log-Message "Tearing down PSSession to $BreakGlassServer"
+        Remove-PsSession -Session $RemoteSession
+        Log-Message "Exited PSSession on $BreakGlassServer"
+
+        # Remove the local copy of BreakGlass.zip
+        Log-Message "Attempting to remove BreakGlass.zip file from $ENV:COMPUTERNAME"
+        Remove-Item -Path ".\BreakGlass.zip"
+        Log-Message "Successfully removed BreakGlass.zip file from $ENV:COMPUTERNAME"
+    }
+    catch {
+        Log-Message $Error[0]
+        exit 1
+    }
+}
+
+<#
+.SYNOPSIS
+    Sync-BreakGlassDirectory - Main function that executes scripts - calls required
+    functions to copy archive from segment server to breakglass server
+.DESCRIPTION
+    This function accepts either a PSCredential object directly, or a username/password,
+    and then determines which was provided. If user/pass, it calls Get-Credential to 
+    convert that to a PSCredential object. It then executes:
+    1. Get-BreakGlassZip
+    2. Push-BreakGlassZip
+    Which copies the BreakGlass directory from the Segement Server to the BreakGlass server
+.PARAMETER Credential
+    PSCredential object needed to create PSSession to Segment Server
+.PARAMETER Username
+    Account username to use to create PSSession
+.PARAMETER Password
+    Password for the associated username provided
+.PARAMETER SegmentServer
+    SHORT hostname for Segment Server (such as znserver)
+.PARAMETER RemoteDirectory
+    Remote directory to copy the archive into
+.PARAMETER BreakGlassServer
+    SHORT hostname for the BreakGlass (destination) server
+.OUTPUTS
+    N/A - None
+.NOTES
+    You can provide either a PSCredential object such as using (Get-Credential)
+    in the function call. OR you can provide it a username/password
+.FUNCTIONALITY
+   Basically the __init__ function of this script
+#>
+function Sync-BreakGlassDirectory {
+    param(
+        [Parameter(Mandatory = $false)]
+        [System.Management.Automation.PSCredential]$Credential = $null,
+        [Parameter(Mandatory = $true)]
+        [string]$RemoteDirectory,
+        [Parameter(Mandatory = $true)]
+        [string]$BreakGlassServer,
+        [Parameter(Mandatory = $true)]
+        [string]$SegmentServer,
+        [Parameter(Mandatory = $false)]
+        [string]$Username,
+        [Parameter(Mandatory = $false)]
+        [string]$Password
+    )
+
+    # If no credential object was provided
+    if ($null -eq $Credential) {
+        # If the username and password fields are ALSO null
+        if (("" -eq $Username) -or ( "" -eq $Password)) {
+            Log-Message "You must either provide a valid credential object, or a valid -Username and -Password"
+            exit 1
+        }
+        else {
+            # Else if a valid user/pass is provided, create PSCredential object by calling Get-Credentials function
+            $Credential = Get-Credentials -Username $Username -Password $Password
+        }
+    } # If the value of $Credential object is not of type PSCredential
+    elseif (-not ($Credential -is [System.Management.Automation.PSCredential])) {
+        # log and exit
+        Log-Message "The value provided for -Credential is not a valid PSCredential object."
+        exit 1
+    }
+
+    # Else execute the functions to copy the breakglass directory
+    Get-BreakGlassZip -Credential $Credential -SegmentServer $SegmentServer
+    Push-BreakGlassZip -Credential $Credential -RemoteDirectory $RemoteDirectory -BreakGlassServer $BreakGlassServer -SegmentServer $SegmentServer
+    Log-Message "Completed copying BreakGlass directory from $SegmentServer to $BreakGlassServer at $RemoteDirectory\BreakGlass-From-$($SegmentServer)"
+}
+
+


### PR DESCRIPTION
I have created a script that you can use to "sync" the contents of "C:\Program Files\Zero Networks\BreakGlass\" from a Segment Server, to a destination server and directory of your choosing. 

The need for this stemmed from wanting to create a dedicated breakglass server that could be used in the event of a breakglass situation (per the recommendations in the admin guide to have a dedicated IP that is allowed to WinRM to all segmented assets). The issue I encountered was that the breakglass script was reliant on the segmentedAssets.json file on the segment server. This file was updated by ZN services on the segment server, but nowhere else. 

So, I created this module, which I can schedule to run hourly. It will compress the BreakGlass directory on the segment server, and copy it to another server (our break glass server). I wanted to share it in case anyone could find it useful. 

I have made sure to document the code and have included a comprehensive README file. 