### PR TITLE
Fix README-regeneration workflow: handle empty subfolders, skip mutations on PRs

### DIFF
--- a/.github/workflows/manual_pwsh_update_readme.yml
+++ b/.github/workflows/manual_pwsh_update_readme.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Github repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check to see if documentation.json exists
         shell: pwsh
         run: |
@@ -30,6 +30,10 @@ jobs:
           Get-Content "$($basePath)/.github/templates/header.md" -Encoding UTF8 | Out-File "$($basePath)/README.md"
           function Add-LineFileInfo {
               param($readmePath, $file, $relativePath, $prefix = "&nbsp;")
+              # Skip silently when the caller passed a null/empty file (e.g. a
+              # subfolder containing no .ps1 files). Get-Help would otherwise
+              # throw "argument is null or empty" and abort the whole workflow.
+              if (-not $file -or [string]::IsNullOrEmpty($file.FullName)) { return }
               # Check for synopsis
               if ((Get-Help $file.Fullname).Synopsis) {
                   $description = (Get-Help $file.Fullname).Synopsis
@@ -66,13 +70,16 @@ jobs:
                   }
 
                   ## If subfolder only has one script, add it to the others.
-                  else {
+                  ## Subfolders with zero .ps1 files (e.g. README-only utility folders)
+                  ## fall through and are skipped — otherwise $singleScripts ends up
+                  ## with file=$null entries that crash Add-LineFileInfo.
+                  elseif ((Get-ChildItem $subfolder.FullName -Recurse -File -Filter '*.ps1').Count -eq 1) {
                       $singleScripts += [PSCustomObject]@{
                           file = Get-ChildItem $subfolder.FullName -File -Filter '*.ps1' -Recurse
                           relativePath = "$($folder.Name)/$($subfolder.Name)"
                           prefix = $subfolder.Name
                       }
-                    }           
+                    }
               }
 
               # add scripts
@@ -97,24 +104,33 @@ jobs:
           Add-Content -Path "$($basePath)/README.md" -Value "`n<br><br>`n![generated_image](https://img.shields.io/badge/generated%20date-$((Get-Date).ToString().Replace(' ','%20'))-blue)"
 
 
-      ## Configure github user settings 
+      ## The steps below mutate the repo (regenerated README.md). They only make
+      ## sense on direct pushes to master, since PRs (especially from forks) lack
+      ## the write permission needed to push and the regeneration step above is
+      ## what we want to validate on PRs anyway.
+      ## Configure github user settings
       - name: Configure Github Settings
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
 
       ## Check for changes prior to pushing
       - name: Check for changes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: git status
 
       ## Add files for changes
       - name: Stage changed files
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: git add .
 
-      ## Commit changes
+      ## Commit changes (skip cleanly when README.md regenerated identically).
       - name: Commit changed files
-        run: git commit -m "Updating README.md"
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: git diff --cached --quiet || git commit -m "Updating README.md"
 
       ## push updates
       - name: Push changes
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         run: git push


### PR DESCRIPTION
## Summary

The auto-README workflow (`.github/workflows/manual_pwsh_update_readme.yml`) has been failing on **every recent push to master** — including upstream maintainers' own commits. This PR fixes the underlying PowerShell crash and a couple of adjacent issues.

### Repro / evidence

Recent master runs of *Powershell - Update Readme.md*:

| Master commit | Result |
|---|---|
| `Merge pull request #43 from shachafzn/common-groups-script` (2026-06-18) | ❌ |
| `Add sentinel config script and parser` (2026-06-03) | ❌ |
| `Create Import-AssetLabels.ps1` (2026-06-02) | ❌ |
| `Update enrollLinuxAsset.ps1 to version 1.3` (2026-04-29) | ❌ |
| `(feat) Added CSV import support` (2026-02-24) | ❌ |

All fail with:

```
Get-Help: ... Cannot validate argument on parameter 'Name'.
The argument is null or empty.
   |   if ((Get-Help $file.Fullname).Synopsis) {
```

### Root cause

The subfolder loop classifies every direct subfolder as either *"> 1 .ps1"* (collapsible) or *"single script"*. The `else` branch silently covers **zero .ps1s too** (e.g. `Connect/Connect-Installer/`, which is README-only):

```powershell
else {
    $singleScripts += [PSCustomObject]@{
        file = Get-ChildItem $subfolder.FullName -File -Filter '*.ps1' -Recurse  # ← $null when count = 0
        ...
    }
}
```

The later `Add-LineFileInfo` then calls `(Get-Help $file.Fullname).Synopsis`, which rejects a null name and aborts the whole job.

## Changes

1. **Tighten the branch** to `elseif ((Get-ChildItem … '*.ps1').Count -eq 1)` so zero-ps1 subfolders are skipped entirely.
2. **Defensive null guard** at the top of `Add-LineFileInfo` so future callers can't reintroduce the same crash.
3. **Gate the commit/push steps on `push` events to `master` only**. PRs (especially from forks) lack the write permission needed to push and would fail at the push step even with the PowerShell crash fixed. The README regeneration now runs as a CI validation on PRs; only direct pushes to `master` mutate the repo.
4. **Make the commit step idempotent**: use `git diff --cached --quiet || git commit ...` so re-pushes that happen to produce an identical README don't fail with *"nothing to commit"*.
5. **Bump `actions/checkout@v2` → `v4`** to silence the Node 20 deprecation warning visible in the same runs.

## Test plan

- [ ] On this PR: confirm the regeneration step completes successfully (the previous failure point) and that the commit/push steps are skipped (`if:` evaluates to false on a fork PR).
- [ ] After merge to `master`: confirm the workflow regenerates `README.md` end-to-end and pushes the update successfully.
- [ ] Confirm subsequent master pushes that don't change README content no longer fail at the commit step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)